### PR TITLE
🔧 Configure to allow eslint-plugin-vue

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 module.exports = {
   root: true,
-  parser: 'babel-eslint',
   parserOptions: {
+    parser: 'babel-eslint',
     sourceType: 'module',
   },
   env: {
@@ -17,8 +17,6 @@ module.exports = {
     $$: true,
   },
   extends: ['airbnb-base', 'prettier'],
-  // required to lint *.vue files
-  plugins: ['html'],
   // add your custom rules here
   rules: {
     // don't require .vue extension when importing


### PR DESCRIPTION
This PR moves the parser into `parserOptions` and removes the `html` plugin so that [`eslint-plugin-vue`](https://github.com/vuejs/eslint-plugin-vue) can be used alongside this config.